### PR TITLE
feat: add the ability to query the details of  fee grant

### DIFF
--- a/proto/caerus/grants/v1/service.proto
+++ b/proto/caerus/grants/v1/service.proto
@@ -3,13 +3,19 @@ package caerus.grants.v1;
 
 option go_package = "github.com/desmos-labs/caerus/routes/grants";
 
+import "gogoproto/gogo.proto";
 import "cosmos_proto/cosmos.proto";
 import "google/protobuf/any.proto";
-import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 
 service GrantsService {
+  // RequestFeeAllowance allows to request a new fee allowance for a given user
   rpc RequestFeeAllowance(RequestFeeAllowanceRequest)
-      returns (google.protobuf.Empty);
+      returns (RequestFeeAllowanceResponse);
+
+  // GetFeeAllowanceDetails allows to get the details of a fee allowance request
+  rpc GetFeeAllowanceDetails(GetFeeAllowanceDetailsRequest)
+      returns (GetFeeAllowanceDetailsResponse);
 }
 
 message RequestFeeAllowanceRequest {
@@ -22,4 +28,35 @@ message RequestFeeAllowanceRequest {
   google.protobuf.Any allowance = 2
       [ (cosmos_proto.accepts_interface) =
             "cosmos.feegrant.v1beta1.AllowanceI" ];
+}
+
+message RequestFeeAllowanceResponse {
+  // ID represents the ID of the fee allowance request
+  string request_id = 1;
+}
+
+message GetFeeAllowanceDetailsRequest {
+  // ID represents the ID of the fee allowance request to query
+  string request_id = 1;
+}
+
+message GetFeeAllowanceDetailsResponse {
+  // UserDesmosAddress represents the Desmos address of the user that
+  // already has (or will be) granted the fee allowance
+  string user_desmos_address = 1;
+
+  // Allowance represents the fee allowance that has been granted to the user
+  // with the specified ID
+  google.protobuf.Any allowance = 2
+      [ (cosmos_proto.accepts_interface) =
+            "cosmos.feegrant.v1beta1.AllowanceI" ];
+
+  // RequestTime represents the time at which the fee allowance has been
+  // requested
+  google.protobuf.Timestamp request_time = 3
+      [ (gogoproto.nullable) = false, (gogoproto.stdtime) = true ];
+
+  // GrantTime represents the time at which the fee allowance has been granted.
+  // If nil, it means that the allowance has not been granted yet
+  google.protobuf.Timestamp grant_time = 4 [ (gogoproto.stdtime) = true ];
 }

--- a/routes/grants/expected_interfaces.go
+++ b/routes/grants/expected_interfaces.go
@@ -12,6 +12,8 @@ type Database interface {
 
 	SaveFeeGrantRequest(request types.FeeGrantRequest) error
 	HasFeeGrantBeenGrantedToUser(appID string, user string) (bool, error)
+
+	GetFeeGrantRequest(appID string, requestID string) (*types.FeeGrantRequest, bool, error)
 }
 
 type ChainClient interface {

--- a/routes/grants/handler.go
+++ b/routes/grants/handler.go
@@ -1,10 +1,13 @@
 package grants
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/x/feegrant"
+	"github.com/cosmos/gogoproto/proto"
 	"google.golang.org/grpc/codes"
 
 	"github.com/desmos-labs/caerus/types"
@@ -29,73 +32,73 @@ func NewHandler(client ChainClient, cdc codec.Codec, db Database) *Handler {
 // --------------------------------------------------------------------------------------------------------------------
 
 // HandleFeeGrantRequest handles the request of a fee grant from the user having the given token
-func (h *Handler) HandleFeeGrantRequest(req *RequestFeeGrantRequest) error {
+func (h *Handler) HandleFeeGrantRequest(req *RequestFeeGrantRequest) (*RequestFeeAllowanceResponse, error) {
 	// Unmarshal the allowance
 	var allowance feegrant.FeeAllowanceI
 	err := h.cdc.UnpackAny(req.Allowance, &allowance)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Get the app details
 	app, found, err := h.db.GetApp(req.AppID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !found {
-		return utils.WrapErr(codes.FailedPrecondition, "application not found")
+		return nil, utils.WrapErr(codes.FailedPrecondition, "application not found")
 	}
 
 	// Check if the app has granted a MsgGrantFeeAllowance permission
 	hasGrantedAuthorization, err := h.chainClient.HasGrantedMsgGrantAllowanceAuthorization(app.WalletAddress)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !hasGrantedAuthorization {
-		return utils.WrapErr(codes.FailedPrecondition, "on-chain authorization not found")
+		return nil, utils.WrapErr(codes.FailedPrecondition, "on-chain authorization not found")
 	}
 
 	// Check if the application has reached the number of requests
 	requestRateLimit, err := h.db.GetAppFeeGrantRequestsLimit(req.AppID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	requestsCount, err := h.db.GetAppFeeGrantRequestsCount(req.AppID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if requestRateLimit > 0 && requestsCount >= requestRateLimit {
-		return utils.NewTooManyRequestsError("number of fee grant requests allowed reached")
+		return nil, utils.NewTooManyRequestsError("number of fee grant requests allowed reached")
 	}
 
 	// Check if the user has already been granted the fee grant
 	hasBeenGranted, err := h.db.HasFeeGrantBeenGrantedToUser(req.AppID, req.DesmosAddress)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if hasBeenGranted {
-		return utils.WrapErr(codes.FailedPrecondition, "you have already been granted the authorizations in the past")
+		return nil, utils.WrapErr(codes.FailedPrecondition, "you have already been granted the authorizations in the past")
 	}
 
 	// Check if the user already has on-chain funds
 	hasFunds, err := h.chainClient.HasFunds(req.DesmosAddress)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if hasFunds {
-		return utils.WrapErr(codes.FailedPrecondition, "you already have funds in your wallet")
+		return nil, utils.WrapErr(codes.FailedPrecondition, "you already have funds in your wallet")
 	}
 
 	// Check if the user already has an on-chain grant
 	hasGrant, err := h.chainClient.HasFeeGrant(req.DesmosAddress, app.WalletAddress)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var grantTime *time.Time
@@ -105,5 +108,38 @@ func (h *Handler) HandleFeeGrantRequest(req *RequestFeeGrantRequest) error {
 
 	// Store the request inside the database
 	request := types.NewFeeGrantRequest(req.AppID, req.DesmosAddress, allowance, time.Now(), grantTime)
-	return h.db.SaveFeeGrantRequest(request)
+	err = h.db.SaveFeeGrantRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return the response
+	return &RequestFeeAllowanceResponse{RequestId: request.ID}, nil
+}
+
+func (h *Handler) HandleRequestFeeGrantDetailsRequest(req *RequestFeeGrantDetailsRequest) (*GetFeeAllowanceDetailsResponse, error) {
+	request, found, err := h.db.GetFeeGrantRequest(req.AppID, req.FeeGrantAllowanceRequestID)
+	if err != nil {
+		return nil, err
+	}
+
+	if !found {
+		return nil, utils.WrapErr(codes.NotFound, "fee grant request not found")
+	}
+
+	msg, ok := request.Allowance.(proto.Message)
+	if !ok {
+		return nil, utils.WrapErr(codes.Internal, fmt.Sprintf("cannot proto marshal %T", msg))
+	}
+	allowanceAny, err := codectypes.NewAnyWithValue(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetFeeAllowanceDetailsResponse{
+		UserDesmosAddress: request.DesmosAddress,
+		Allowance:         allowanceAny,
+		RequestTime:       request.RequestTime,
+		GrantTime:         request.GrantTime,
+	}, nil
 }

--- a/routes/grants/server.go
+++ b/routes/grants/server.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/posthog/posthog-go"
-	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/desmos-labs/caerus/analytics"
 	"github.com/desmos-labs/caerus/authentication"
@@ -31,15 +30,9 @@ func NewServerFromEnvVariables(chainClient ChainClient, cdc codec.Codec, db Data
 	)
 }
 
-func (s *Server) RequestFeeAllowance(ctx context.Context, request *RequestFeeAllowanceRequest) (*emptypb.Empty, error) {
+// RequestFeeAllowance implements GrantsServiceServer
+func (s *Server) RequestFeeAllowance(ctx context.Context, request *RequestFeeAllowanceRequest) (*RequestFeeAllowanceResponse, error) {
 	appData, err := authentication.GetAuthenticatedAppData(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Handle the request
-	req := NewRequestFeeGrantRequest(appData.AppID, request.UserDesmosAddress, request.Allowance)
-	err = s.handler.HandleFeeGrantRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -52,5 +45,19 @@ func (s *Server) RequestFeeAllowance(ctx context.Context, request *RequestFeeAll
 			Set(analytics.KeyUserAddress, request.UserDesmosAddress),
 	})
 
-	return &emptypb.Empty{}, nil
+	// Handle the request
+	req := NewRequestFeeGrantRequest(appData.AppID, request.UserDesmosAddress, request.Allowance)
+	return s.handler.HandleFeeGrantRequest(req)
+}
+
+// GetFeeAllowanceDetails implements GrantsServiceServer
+func (s *Server) GetFeeAllowanceDetails(ctx context.Context, request *GetFeeAllowanceDetailsRequest) (*GetFeeAllowanceDetailsResponse, error) {
+	appData, err := authentication.GetAuthenticatedAppData(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle the request
+	req := NewRequestFeeGrantDetailsRequest(appData.AppID, request.RequestId)
+	return s.handler.HandleRequestFeeGrantDetailsRequest(req)
 }

--- a/routes/grants/service.pb.go
+++ b/routes/grants/service.pb.go
@@ -8,21 +8,25 @@ import (
 	fmt "fmt"
 	_ "github.com/cosmos/cosmos-proto"
 	types "github.com/cosmos/cosmos-sdk/codec/types"
+	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/cosmos/gogoproto/grpc"
 	proto "github.com/cosmos/gogoproto/proto"
+	github_com_cosmos_gogoproto_types "github.com/cosmos/gogoproto/types"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	_ "google.golang.org/protobuf/types/known/timestamppb"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+	time "time"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
+var _ = time.Kitchen
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -86,34 +90,213 @@ func (m *RequestFeeAllowanceRequest) GetAllowance() *types.Any {
 	return nil
 }
 
+type RequestFeeAllowanceResponse struct {
+	// ID represents the ID of the fee allowance request
+	RequestId string `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+}
+
+func (m *RequestFeeAllowanceResponse) Reset()         { *m = RequestFeeAllowanceResponse{} }
+func (m *RequestFeeAllowanceResponse) String() string { return proto.CompactTextString(m) }
+func (*RequestFeeAllowanceResponse) ProtoMessage()    {}
+func (*RequestFeeAllowanceResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_3408ad1c94df29ed, []int{1}
+}
+func (m *RequestFeeAllowanceResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *RequestFeeAllowanceResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_RequestFeeAllowanceResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *RequestFeeAllowanceResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RequestFeeAllowanceResponse.Merge(m, src)
+}
+func (m *RequestFeeAllowanceResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *RequestFeeAllowanceResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_RequestFeeAllowanceResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RequestFeeAllowanceResponse proto.InternalMessageInfo
+
+func (m *RequestFeeAllowanceResponse) GetRequestId() string {
+	if m != nil {
+		return m.RequestId
+	}
+	return ""
+}
+
+type GetFeeAllowanceDetailsRequest struct {
+	// ID represents the ID of the fee allowance request to query
+	RequestId string `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+}
+
+func (m *GetFeeAllowanceDetailsRequest) Reset()         { *m = GetFeeAllowanceDetailsRequest{} }
+func (m *GetFeeAllowanceDetailsRequest) String() string { return proto.CompactTextString(m) }
+func (*GetFeeAllowanceDetailsRequest) ProtoMessage()    {}
+func (*GetFeeAllowanceDetailsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_3408ad1c94df29ed, []int{2}
+}
+func (m *GetFeeAllowanceDetailsRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetFeeAllowanceDetailsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetFeeAllowanceDetailsRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetFeeAllowanceDetailsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetFeeAllowanceDetailsRequest.Merge(m, src)
+}
+func (m *GetFeeAllowanceDetailsRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetFeeAllowanceDetailsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetFeeAllowanceDetailsRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetFeeAllowanceDetailsRequest proto.InternalMessageInfo
+
+func (m *GetFeeAllowanceDetailsRequest) GetRequestId() string {
+	if m != nil {
+		return m.RequestId
+	}
+	return ""
+}
+
+type GetFeeAllowanceDetailsResponse struct {
+	// UserDesmosAddress represents the Desmos address of the user that
+	// already has (or will be) granted the fee allowance
+	UserDesmosAddress string `protobuf:"bytes,1,opt,name=user_desmos_address,json=userDesmosAddress,proto3" json:"user_desmos_address,omitempty"`
+	// Allowance represents the fee allowance that has been granted to the user
+	// with the specified ID
+	Allowance *types.Any `protobuf:"bytes,2,opt,name=allowance,proto3" json:"allowance,omitempty"`
+	// RequestTime represents the time at which the fee allowance has been
+	// requested
+	RequestTime time.Time `protobuf:"bytes,3,opt,name=request_time,json=requestTime,proto3,stdtime" json:"request_time"`
+	// GrantTime represents the time at which the fee allowance has been granted.
+	// If nil, it means that the allowance has not been granted yet
+	GrantTime *time.Time `protobuf:"bytes,4,opt,name=grant_time,json=grantTime,proto3,stdtime" json:"grant_time,omitempty"`
+}
+
+func (m *GetFeeAllowanceDetailsResponse) Reset()         { *m = GetFeeAllowanceDetailsResponse{} }
+func (m *GetFeeAllowanceDetailsResponse) String() string { return proto.CompactTextString(m) }
+func (*GetFeeAllowanceDetailsResponse) ProtoMessage()    {}
+func (*GetFeeAllowanceDetailsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_3408ad1c94df29ed, []int{3}
+}
+func (m *GetFeeAllowanceDetailsResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetFeeAllowanceDetailsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetFeeAllowanceDetailsResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetFeeAllowanceDetailsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetFeeAllowanceDetailsResponse.Merge(m, src)
+}
+func (m *GetFeeAllowanceDetailsResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetFeeAllowanceDetailsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetFeeAllowanceDetailsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetFeeAllowanceDetailsResponse proto.InternalMessageInfo
+
+func (m *GetFeeAllowanceDetailsResponse) GetUserDesmosAddress() string {
+	if m != nil {
+		return m.UserDesmosAddress
+	}
+	return ""
+}
+
+func (m *GetFeeAllowanceDetailsResponse) GetAllowance() *types.Any {
+	if m != nil {
+		return m.Allowance
+	}
+	return nil
+}
+
+func (m *GetFeeAllowanceDetailsResponse) GetRequestTime() time.Time {
+	if m != nil {
+		return m.RequestTime
+	}
+	return time.Time{}
+}
+
+func (m *GetFeeAllowanceDetailsResponse) GetGrantTime() *time.Time {
+	if m != nil {
+		return m.GrantTime
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*RequestFeeAllowanceRequest)(nil), "caerus.grants.v1.RequestFeeAllowanceRequest")
+	proto.RegisterType((*RequestFeeAllowanceResponse)(nil), "caerus.grants.v1.RequestFeeAllowanceResponse")
+	proto.RegisterType((*GetFeeAllowanceDetailsRequest)(nil), "caerus.grants.v1.GetFeeAllowanceDetailsRequest")
+	proto.RegisterType((*GetFeeAllowanceDetailsResponse)(nil), "caerus.grants.v1.GetFeeAllowanceDetailsResponse")
 }
 
 func init() { proto.RegisterFile("caerus/grants/v1/service.proto", fileDescriptor_3408ad1c94df29ed) }
 
 var fileDescriptor_3408ad1c94df29ed = []byte{
-	// 319 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x91, 0xdf, 0x4a, 0x3a, 0x41,
-	0x14, 0xc7, 0x9d, 0xdf, 0xc5, 0x0f, 0xdc, 0x08, 0x6a, 0x8d, 0xd0, 0x0d, 0x06, 0xf1, 0x22, 0x84,
-	0xf2, 0x0c, 0x6b, 0x4f, 0xa0, 0x64, 0xd1, 0xad, 0xdd, 0xd9, 0x85, 0xcc, 0xae, 0xc7, 0x4d, 0x58,
-	0x77, 0x6c, 0xfe, 0x6c, 0xf8, 0x16, 0x3d, 0x46, 0x0f, 0xd0, 0x43, 0x44, 0x57, 0x5e, 0x76, 0x19,
-	0xfa, 0x22, 0xe1, 0xcc, 0x6e, 0x81, 0xd5, 0xe5, 0x99, 0xcf, 0x70, 0xbe, 0x7f, 0x8e, 0x47, 0x63,
-	0x8e, 0xd2, 0x28, 0x96, 0x48, 0x9e, 0x69, 0xc5, 0xf2, 0x90, 0x29, 0x94, 0xf9, 0x2c, 0x46, 0x58,
-	0x48, 0xa1, 0x85, 0x7f, 0xe0, 0x38, 0x38, 0x0e, 0x79, 0x18, 0x34, 0x62, 0xa1, 0xe6, 0x42, 0x8d,
-	0x2d, 0x67, 0x6e, 0x70, 0x9f, 0x83, 0x46, 0x22, 0x44, 0x92, 0x22, 0xb3, 0x53, 0x64, 0xa6, 0x8c,
-	0x67, 0xcb, 0x02, 0x9d, 0xec, 0x22, 0x9c, 0x2f, 0x74, 0x01, 0x5b, 0xcf, 0xc4, 0x0b, 0x86, 0xf8,
-	0x60, 0x50, 0xe9, 0x2b, 0xc4, 0x5e, 0x9a, 0x8a, 0x47, 0x9e, 0xc5, 0x58, 0x3c, 0xf9, 0xe0, 0xd5,
-	0x8c, 0x42, 0x39, 0x9e, 0xa0, 0x15, 0xe6, 0x93, 0x89, 0x44, 0xa5, 0xea, 0xa4, 0x49, 0xda, 0xd5,
-	0xe1, 0xe1, 0x16, 0x5d, 0x5a, 0xd2, 0x73, 0xc0, 0x1f, 0x79, 0x55, 0x5e, 0xee, 0xa8, 0xff, 0x6b,
-	0x92, 0xf6, 0x5e, 0xf7, 0x08, 0x9c, 0x3e, 0x94, 0xfa, 0xd0, 0xcb, 0x96, 0xfd, 0xd3, 0xb7, 0x97,
-	0x4e, 0xab, 0x48, 0x30, 0x45, 0xb4, 0x19, 0x21, 0x0f, 0x23, 0xd4, 0x3c, 0x84, 0x2f, 0x1b, 0x37,
-	0xc3, 0xef, 0x75, 0xdd, 0xd4, 0xdb, 0xbf, 0xb6, 0x55, 0xdc, 0xba, 0x9a, 0xfc, 0x3b, 0xaf, 0xf6,
-	0x8b, 0x75, 0xff, 0x1c, 0x76, 0x8b, 0x83, 0xbf, 0x13, 0x06, 0xc7, 0x3f, 0xec, 0x0d, 0xb6, 0xf5,
-	0xf4, 0x07, 0xaf, 0x6b, 0x4a, 0x56, 0x6b, 0x4a, 0x3e, 0xd6, 0x94, 0x3c, 0x6d, 0x68, 0x65, 0xb5,
-	0xa1, 0x95, 0xf7, 0x0d, 0xad, 0x8c, 0xce, 0x92, 0x99, 0xbe, 0x37, 0x11, 0xc4, 0x62, 0xce, 0x5c,
-	0x2f, 0x9d, 0x94, 0x47, 0x8a, 0x15, 0xe7, 0x94, 0xc2, 0x68, 0x2c, 0xaf, 0x1a, 0xfd, 0xb7, 0x6b,
-	0x2f, 0x3e, 0x03, 0x00, 0x00, 0xff, 0xff, 0xef, 0x38, 0xa3, 0x7d, 0xed, 0x01, 0x00, 0x00,
+	// 465 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x94, 0x41, 0x6f, 0xd3, 0x30,
+	0x14, 0xc7, 0xeb, 0x32, 0x21, 0xea, 0x81, 0x04, 0xde, 0x84, 0x4a, 0xd0, 0xdc, 0xa9, 0x07, 0x34,
+	0x09, 0x6a, 0xd3, 0x71, 0x45, 0xa0, 0x56, 0x83, 0x6a, 0xd7, 0xc2, 0x69, 0x97, 0xca, 0x49, 0xde,
+	0x42, 0xa4, 0x24, 0x2e, 0xb6, 0x13, 0x34, 0x71, 0xe1, 0x23, 0xec, 0x63, 0xf0, 0x01, 0x10, 0x9f,
+	0x61, 0xe2, 0xb4, 0x23, 0x27, 0x40, 0xed, 0x17, 0x41, 0xb1, 0x1d, 0x10, 0x5b, 0xc7, 0x76, 0xdc,
+	0x2d, 0xf6, 0xcf, 0xef, 0xff, 0xde, 0xf3, 0xfb, 0xc7, 0x98, 0x46, 0x02, 0x54, 0xa9, 0x79, 0xa2,
+	0x44, 0x61, 0x34, 0xaf, 0x86, 0x5c, 0x83, 0xaa, 0xd2, 0x08, 0xd8, 0x5c, 0x49, 0x23, 0xc9, 0x5d,
+	0xc7, 0x99, 0xe3, 0xac, 0x1a, 0x06, 0x9b, 0x89, 0x4c, 0xa4, 0x85, 0xbc, 0xfe, 0x72, 0xe7, 0x82,
+	0x07, 0x91, 0xd4, 0xb9, 0xd4, 0x33, 0x07, 0xdc, 0xa2, 0x41, 0x89, 0x94, 0x49, 0x06, 0xdc, 0xae,
+	0xc2, 0xf2, 0x90, 0x8b, 0xe2, 0xc8, 0xa3, 0xde, 0x59, 0x64, 0xd2, 0x1c, 0xb4, 0x11, 0xf9, 0xdc,
+	0x1d, 0xe8, 0x7f, 0x46, 0x38, 0x98, 0xc2, 0xfb, 0x12, 0xb4, 0x79, 0x0d, 0x30, 0xca, 0x32, 0xf9,
+	0x41, 0x14, 0x11, 0xf8, 0x2d, 0xc2, 0xf0, 0x46, 0xa9, 0x41, 0xcd, 0x62, 0xb0, 0xc9, 0x45, 0x1c,
+	0x2b, 0xd0, 0xba, 0x8b, 0xb6, 0xd1, 0x4e, 0x67, 0x7a, 0xaf, 0x46, 0x7b, 0x96, 0x8c, 0x1c, 0x20,
+	0x07, 0xb8, 0x23, 0x1a, 0x8d, 0x6e, 0x7b, 0x1b, 0xed, 0xac, 0xef, 0x6e, 0x32, 0x57, 0x03, 0x6b,
+	0x6a, 0x60, 0xa3, 0xe2, 0x68, 0xfc, 0xe8, 0xdb, 0x97, 0x41, 0xdf, 0x77, 0x71, 0x08, 0x60, 0xbb,
+	0x67, 0xd5, 0x30, 0x04, 0x23, 0x86, 0xec, 0x4f, 0x19, 0xfb, 0xd3, 0xbf, 0x72, 0xfd, 0xe7, 0xf8,
+	0xe1, 0xca, 0x4a, 0xf5, 0x5c, 0x16, 0x1a, 0xc8, 0x16, 0xc6, 0xca, 0xe1, 0x59, 0x1a, 0xfb, 0x0a,
+	0x3b, 0x7e, 0x67, 0x3f, 0xee, 0xbf, 0xc0, 0x5b, 0x13, 0xf8, 0x27, 0x72, 0x0f, 0x8c, 0x48, 0x33,
+	0xdd, 0xb4, 0x7a, 0x49, 0xfc, 0xd7, 0x36, 0xa6, 0x17, 0x09, 0xf8, 0x0a, 0xae, 0xd1, 0x65, 0x91,
+	0x09, 0xbe, 0xdd, 0x74, 0x53, 0x8f, 0xbc, 0x7b, 0xc3, 0xca, 0x07, 0xe7, 0xe4, 0xdf, 0x36, 0x7e,
+	0x18, 0xdf, 0x3a, 0xf9, 0xd1, 0x6b, 0x1d, 0xff, 0xec, 0xa1, 0xe9, 0xba, 0x8f, 0xac, 0x19, 0x79,
+	0x89, 0xb1, 0xcd, 0xe7, 0x64, 0xd6, 0x2e, 0x95, 0x59, 0xb3, 0x12, 0x1d, 0x1b, 0x53, 0xef, 0xee,
+	0x7e, 0x6a, 0xe3, 0x3b, 0x13, 0x6b, 0xee, 0x37, 0xce, 0xf8, 0x44, 0xe1, 0x8d, 0x15, 0x83, 0x24,
+	0x4f, 0xd8, 0xd9, 0x5f, 0x81, 0x5d, 0xec, 0xcc, 0x60, 0x70, 0xc5, 0xd3, 0x7e, 0x36, 0x1f, 0xf1,
+	0xfd, 0xd5, 0xd3, 0x23, 0xfc, 0xbc, 0xd0, 0x7f, 0x8d, 0x12, 0x3c, 0xbd, 0x7a, 0x80, 0x4b, 0x3e,
+	0x7e, 0x75, 0xb2, 0xa0, 0xe8, 0x74, 0x41, 0xd1, 0xaf, 0x05, 0x45, 0xc7, 0x4b, 0xda, 0x3a, 0x5d,
+	0xd2, 0xd6, 0xf7, 0x25, 0x6d, 0x1d, 0x3c, 0x4e, 0x52, 0xf3, 0xae, 0x0c, 0x59, 0x24, 0x73, 0xee,
+	0x6c, 0x33, 0xc8, 0x44, 0xa8, 0xb9, 0x7f, 0x34, 0x94, 0x2c, 0x0d, 0x34, 0x6f, 0x47, 0x78, 0xd3,
+	0x5e, 0xf7, 0xb3, 0xdf, 0x01, 0x00, 0x00, 0xff, 0xff, 0xe8, 0x2c, 0xc2, 0x32, 0x53, 0x04, 0x00,
+	0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -128,7 +311,10 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type GrantsServiceClient interface {
-	RequestFeeAllowance(ctx context.Context, in *RequestFeeAllowanceRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// RequestFeeAllowance allows to request a new fee allowance for a given user
+	RequestFeeAllowance(ctx context.Context, in *RequestFeeAllowanceRequest, opts ...grpc.CallOption) (*RequestFeeAllowanceResponse, error)
+	// GetFeeAllowanceDetails allows to get the details of a fee allowance request
+	GetFeeAllowanceDetails(ctx context.Context, in *GetFeeAllowanceDetailsRequest, opts ...grpc.CallOption) (*GetFeeAllowanceDetailsResponse, error)
 }
 
 type grantsServiceClient struct {
@@ -139,9 +325,18 @@ func NewGrantsServiceClient(cc grpc1.ClientConn) GrantsServiceClient {
 	return &grantsServiceClient{cc}
 }
 
-func (c *grantsServiceClient) RequestFeeAllowance(ctx context.Context, in *RequestFeeAllowanceRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	out := new(emptypb.Empty)
+func (c *grantsServiceClient) RequestFeeAllowance(ctx context.Context, in *RequestFeeAllowanceRequest, opts ...grpc.CallOption) (*RequestFeeAllowanceResponse, error) {
+	out := new(RequestFeeAllowanceResponse)
 	err := c.cc.Invoke(ctx, "/caerus.grants.v1.GrantsService/RequestFeeAllowance", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *grantsServiceClient) GetFeeAllowanceDetails(ctx context.Context, in *GetFeeAllowanceDetailsRequest, opts ...grpc.CallOption) (*GetFeeAllowanceDetailsResponse, error) {
+	out := new(GetFeeAllowanceDetailsResponse)
+	err := c.cc.Invoke(ctx, "/caerus.grants.v1.GrantsService/GetFeeAllowanceDetails", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -150,15 +345,21 @@ func (c *grantsServiceClient) RequestFeeAllowance(ctx context.Context, in *Reque
 
 // GrantsServiceServer is the server API for GrantsService service.
 type GrantsServiceServer interface {
-	RequestFeeAllowance(context.Context, *RequestFeeAllowanceRequest) (*emptypb.Empty, error)
+	// RequestFeeAllowance allows to request a new fee allowance for a given user
+	RequestFeeAllowance(context.Context, *RequestFeeAllowanceRequest) (*RequestFeeAllowanceResponse, error)
+	// GetFeeAllowanceDetails allows to get the details of a fee allowance request
+	GetFeeAllowanceDetails(context.Context, *GetFeeAllowanceDetailsRequest) (*GetFeeAllowanceDetailsResponse, error)
 }
 
 // UnimplementedGrantsServiceServer can be embedded to have forward compatible implementations.
 type UnimplementedGrantsServiceServer struct {
 }
 
-func (*UnimplementedGrantsServiceServer) RequestFeeAllowance(ctx context.Context, req *RequestFeeAllowanceRequest) (*emptypb.Empty, error) {
+func (*UnimplementedGrantsServiceServer) RequestFeeAllowance(ctx context.Context, req *RequestFeeAllowanceRequest) (*RequestFeeAllowanceResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RequestFeeAllowance not implemented")
+}
+func (*UnimplementedGrantsServiceServer) GetFeeAllowanceDetails(ctx context.Context, req *GetFeeAllowanceDetailsRequest) (*GetFeeAllowanceDetailsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetFeeAllowanceDetails not implemented")
 }
 
 func RegisterGrantsServiceServer(s grpc1.Server, srv GrantsServiceServer) {
@@ -183,6 +384,24 @@ func _GrantsService_RequestFeeAllowance_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _GrantsService_GetFeeAllowanceDetails_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetFeeAllowanceDetailsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GrantsServiceServer).GetFeeAllowanceDetails(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/caerus.grants.v1.GrantsService/GetFeeAllowanceDetails",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GrantsServiceServer).GetFeeAllowanceDetails(ctx, req.(*GetFeeAllowanceDetailsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _GrantsService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "caerus.grants.v1.GrantsService",
 	HandlerType: (*GrantsServiceServer)(nil),
@@ -190,6 +409,10 @@ var _GrantsService_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RequestFeeAllowance",
 			Handler:    _GrantsService_RequestFeeAllowance_Handler,
+		},
+		{
+			MethodName: "GetFeeAllowanceDetails",
+			Handler:    _GrantsService_GetFeeAllowanceDetails_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -238,6 +461,126 @@ func (m *RequestFeeAllowanceRequest) MarshalToSizedBuffer(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 
+func (m *RequestFeeAllowanceResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RequestFeeAllowanceResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RequestFeeAllowanceResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.RequestId) > 0 {
+		i -= len(m.RequestId)
+		copy(dAtA[i:], m.RequestId)
+		i = encodeVarintService(dAtA, i, uint64(len(m.RequestId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetFeeAllowanceDetailsRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetFeeAllowanceDetailsRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetFeeAllowanceDetailsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.RequestId) > 0 {
+		i -= len(m.RequestId)
+		copy(dAtA[i:], m.RequestId)
+		i = encodeVarintService(dAtA, i, uint64(len(m.RequestId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetFeeAllowanceDetailsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetFeeAllowanceDetailsResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetFeeAllowanceDetailsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.GrantTime != nil {
+		n2, err2 := github_com_cosmos_gogoproto_types.StdTimeMarshalTo(*m.GrantTime, dAtA[i-github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.GrantTime):])
+		if err2 != nil {
+			return 0, err2
+		}
+		i -= n2
+		i = encodeVarintService(dAtA, i, uint64(n2))
+		i--
+		dAtA[i] = 0x22
+	}
+	n3, err3 := github_com_cosmos_gogoproto_types.StdTimeMarshalTo(m.RequestTime, dAtA[i-github_com_cosmos_gogoproto_types.SizeOfStdTime(m.RequestTime):])
+	if err3 != nil {
+		return 0, err3
+	}
+	i -= n3
+	i = encodeVarintService(dAtA, i, uint64(n3))
+	i--
+	dAtA[i] = 0x1a
+	if m.Allowance != nil {
+		{
+			size, err := m.Allowance.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintService(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.UserDesmosAddress) > 0 {
+		i -= len(m.UserDesmosAddress)
+		copy(dAtA[i:], m.UserDesmosAddress)
+		i = encodeVarintService(dAtA, i, uint64(len(m.UserDesmosAddress)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintService(dAtA []byte, offset int, v uint64) int {
 	offset -= sovService(v)
 	base := offset
@@ -261,6 +604,55 @@ func (m *RequestFeeAllowanceRequest) Size() (n int) {
 	}
 	if m.Allowance != nil {
 		l = m.Allowance.Size()
+		n += 1 + l + sovService(uint64(l))
+	}
+	return n
+}
+
+func (m *RequestFeeAllowanceResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.RequestId)
+	if l > 0 {
+		n += 1 + l + sovService(uint64(l))
+	}
+	return n
+}
+
+func (m *GetFeeAllowanceDetailsRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.RequestId)
+	if l > 0 {
+		n += 1 + l + sovService(uint64(l))
+	}
+	return n
+}
+
+func (m *GetFeeAllowanceDetailsResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.UserDesmosAddress)
+	if l > 0 {
+		n += 1 + l + sovService(uint64(l))
+	}
+	if m.Allowance != nil {
+		l = m.Allowance.Size()
+		n += 1 + l + sovService(uint64(l))
+	}
+	l = github_com_cosmos_gogoproto_types.SizeOfStdTime(m.RequestTime)
+	n += 1 + l + sovService(uint64(l))
+	if m.GrantTime != nil {
+		l = github_com_cosmos_gogoproto_types.SizeOfStdTime(*m.GrantTime)
 		n += 1 + l + sovService(uint64(l))
 	}
 	return n
@@ -366,6 +758,357 @@ func (m *RequestFeeAllowanceRequest) Unmarshal(dAtA []byte) error {
 				m.Allowance = &types.Any{}
 			}
 			if err := m.Allowance.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipService(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthService
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RequestFeeAllowanceResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowService
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RequestFeeAllowanceResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RequestFeeAllowanceResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequestId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowService
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthService
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthService
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RequestId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipService(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthService
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetFeeAllowanceDetailsRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowService
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetFeeAllowanceDetailsRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetFeeAllowanceDetailsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequestId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowService
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthService
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthService
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RequestId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipService(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthService
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetFeeAllowanceDetailsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowService
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetFeeAllowanceDetailsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetFeeAllowanceDetailsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UserDesmosAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowService
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthService
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthService
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UserDesmosAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Allowance", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowService
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthService
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthService
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Allowance == nil {
+				m.Allowance = &types.Any{}
+			}
+			if err := m.Allowance.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequestTime", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowService
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthService
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthService
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := github_com_cosmos_gogoproto_types.StdTimeUnmarshal(&m.RequestTime, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field GrantTime", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowService
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthService
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthService
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.GrantTime == nil {
+				m.GrantTime = new(time.Time)
+			}
+			if err := github_com_cosmos_gogoproto_types.StdTimeUnmarshal(m.GrantTime, dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/routes/grants/types.go
+++ b/routes/grants/types.go
@@ -22,3 +22,18 @@ func NewRequestFeeGrantRequest(appID string, desmosAddress string, allowance *co
 		Allowance:     allowance,
 	}
 }
+
+type RequestFeeGrantDetailsRequest struct {
+	// AppID represents the ID of the application that is requesting the fee grant details
+	AppID string
+
+	// FeeGrantAllowanceRequestID represents the id of the fee grant request for which to get the details
+	FeeGrantAllowanceRequestID string
+}
+
+func NewRequestFeeGrantDetailsRequest(appID string, feeGrantAllowanceRequestID string) *RequestFeeGrantDetailsRequest {
+	return &RequestFeeGrantDetailsRequest{
+		AppID:                      appID,
+		FeeGrantAllowanceRequestID: feeGrantAllowanceRequestID,
+	}
+}


### PR DESCRIPTION
## Description

This PR updates the `RequestFeeAllowance` method to return the id of the new fee grant request. It also adds a new `GetFeeAllowanceDetails` that applications can use in order to get the details of a fee grant allowance they requested, given its id.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)