### PR TITLE
refactor: remove image hash computation when uploading file

### DIFF
--- a/database/media.go
+++ b/database/media.go
@@ -1,8 +1,0 @@
-package database
-
-// SaveMediaHash allows to save the given image hash inside the database
-func (db *Database) SaveMediaHash(imageUrl string, hash string) error {
-	stmt := `INSERT INTO files_hashes (file_name, hash) VALUES ($1, $2) ON CONFLICT (file_name) DO UPDATE SET hash = $2`
-	_, err := db.SQL.Exec(stmt, imageUrl, hash)
-	return err
-}

--- a/database/schema/02-media.sql
+++ b/database/schema/02-media.sql
@@ -1,8 +1,0 @@
-/*
- * Contains all the hashes of the images generated using BlurHash (https://blurha.sh/).
- */
-CREATE TABLE files_hashes
-(
-    file_name TEXT NOT NULL PRIMARY KEY,
-    hash      TEXT NOT NULL
-);

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 	// Register the default routes
 	serverRunner.SetServiceRegistrar(func(context runner.Context, server *grpc.Server) {
 		applications.RegisterApplicationServiceServer(server, applications.NewServerFromEnvVariables(context.Database))
-		files.RegisterFilesServiceServer(server, files.NewServerFromEnvVariables(context.Database))
+		files.RegisterFilesServiceServer(server, files.NewServerFromEnvVariables())
 		grants.RegisterGrantsServiceServer(server, grants.NewServerFromEnvVariables(context.ChainClient, context.Codec, context.Database))
 		notifications.RegisterNotificationsServiceServer(server, notifications.NewServerFromEnvVariables(context.NotificationsClient, context.Database))
 		users.RegisterUsersServiceServer(server, users.NewServerFromEnvVariables(context.Codec, context.Amino, context.Database))

--- a/routes/files/expected_interfaces.go
+++ b/routes/files/expected_interfaces.go
@@ -1,5 +1,0 @@
-package files
-
-type Database interface {
-	SaveMediaHash(fileName string, hash string) error
-}

--- a/routes/files/server.go
+++ b/routes/files/server.go
@@ -21,9 +21,9 @@ func NewServer(handler *Handler) *Server {
 	}
 }
 
-func NewServerFromEnvVariables(db Database) *Server {
+func NewServerFromEnvVariables() *Server {
 	return &Server{
-		handler: NewHandlerFromEnvVariables(db),
+		handler: NewHandlerFromEnvVariables(),
 	}
 }
 
@@ -49,11 +49,13 @@ func (s *Server) UploadFile(stream FilesService_UploadFileServer) error {
 			}
 
 			// Now, handle the request
-			tempFilePath, res, err := s.handler.UploadFile(filePath)
+			res, err := s.handler.UploadFile(filePath)
 			if err != nil {
 				return err
 			}
-			os.Remove(tempFilePath)
+
+			// Remove the file from the local storage
+			os.Remove(filePath)
 
 			return stream.SendAndClose(res)
 		}

--- a/routes/files/server_test.go
+++ b/routes/files/server_test.go
@@ -50,7 +50,7 @@ func (suite *FilesServerTestSuite) SetupSuite() {
 
 	// Create the handler
 	suite.storage = files.NewIPFSStorage("https://ipfs.desmos.network")
-	suite.handler = files.NewHandler(suite.tempDir, suite.storage, suite.db)
+	suite.handler = files.NewHandler(suite.tempDir, suite.storage)
 
 	// Create the server
 	suite.server = testutils.CreateServer(suite.db)
@@ -180,12 +180,6 @@ func (suite *FilesServerTestSuite) TestUploadMedia() {
 			shouldErr: false,
 			check: func(res *files.UploadFileResponse) {
 				suite.Require().NotEmpty(res.FileName)
-
-				// Make sure the image hash has been saved properly
-				var hash string
-				err := suite.db.SQL.QueryRow(`SELECT hash FROM files_hashes WHERE file_name = $1`, res.FileName).Scan(&hash)
-				suite.Require().NoError(err)
-				suite.Require().Equal("L-J[3W*E#u;2%Lb:sE$OWBe@R%NH", hash)
 			},
 		},
 	}
@@ -204,7 +198,7 @@ func (suite *FilesServerTestSuite) TestUploadMedia() {
 			}
 
 			// Perform the request
-			res, err := suite.uploadFile(ctx, path.Join(suite.tempDir, "temp_file.jpeg"))
+			res, err := suite.uploadFile(ctx, "/home/riccardo/Downloads/Riccardo_Montagnin_A_crowd_of_people_walking_in_the_middle_of_N_09606c49-0ecf-4a2c-aef8-be2b3a99a7d6.png")
 
 			// Check the response
 			if tc.shouldErr {

--- a/routes/files/server_test.go
+++ b/routes/files/server_test.go
@@ -198,7 +198,7 @@ func (suite *FilesServerTestSuite) TestUploadMedia() {
 			}
 
 			// Perform the request
-			res, err := suite.uploadFile(ctx, "/home/riccardo/Downloads/Riccardo_Montagnin_A_crowd_of_people_walking_in_the_middle_of_N_09606c49-0ecf-4a2c-aef8-be2b3a99a7d6.png")
+			res, err := suite.uploadFile(ctx, path.Join(suite.tempDir, "temp_file.jpeg"))
 
 			// Check the response
 			if tc.shouldErr {


### PR DESCRIPTION
## Description

This PR removes the BlurHash computation process when uploading an image to the server. This is done in order to speed up the image upload process and avoid any useless overhead (since image hashes are never exposed anyway). 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)